### PR TITLE
Move Arduino-pin defines to header

### DIFF
--- a/WNC14A2AInterface/WNC14A2AInterface.h
+++ b/WNC14A2AInterface/WNC14A2AInterface.h
@@ -41,6 +41,43 @@
 
 #define WNC14A2A_SOCKET_COUNT WncController::MAX_NUM_WNC_SOCKETS 
 
+// If target board does not support Arduino pins, define pins as Not Connected
+#if defined(TARGET_FF_ARDUINO)
+#if !defined(MBED_CONF_WNC14A2A_LIBRARY_WNC_RX_BOOT_SEL)
+#define MBED_CONF_WNC14A2A_LIBRARY_WNC_RX_BOOT_SEL                     D1
+#endif
+#if !defined(MBED_CONF_WNC14A2A_LIBRARY_WNC_POWER_ON)
+#define MBED_CONF_WNC14A2A_LIBRARY_WNC_POWER_ON                        D2
+#endif
+#if !defined(MBED_CONF_WNC14A2A_LIBRARY_WNC_WAKEUP)
+#define MBED_CONF_WNC14A2A_LIBRARY_WNC_WAKEUP                          D6
+#endif
+#if !defined(MBED_CONF_WNC14A2A_LIBRARY_WNC_RESET)
+#define MBED_CONF_WNC14A2A_LIBRARY_WNC_RESET                           D8
+#endif
+#if !defined(MBED_CONF_WNC14A2A_LIBRARY_WNC_LVLTRANSLATOR)
+#define MBED_CONF_WNC14A2A_LIBRARY_WNC_LVLTRANSLATOR                   D9
+#endif
+#if !defined(MBED_CONF_WNC14A2A_LIBRARY_WNC_CTS)
+#define MBED_CONF_WNC14A2A_LIBRARY_WNC_CTS                             D10
+#endif
+#if !defined(MBED_CONF_WNC14A2A_LIBRARY_WNC_RXD)
+#define MBED_CONF_WNC14A2A_LIBRARY_WNC_RXD                             D11
+#endif
+#if !defined(MBED_CONF_WNC14A2A_LIBRARY_WNC_TXD)
+#define MBED_CONF_WNC14A2A_LIBRARY_WNC_TXD                             D12
+#endif
+#else // !defined(TARGET_FF_ARDUINO)
+#define MBED_CONF_WNC14A2A_LIBRARY_WNC_RX_BOOT_SEL                     NC
+#define MBED_CONF_WNC14A2A_LIBRARY_WNC_POWER_ON                        NC
+#define MBED_CONF_WNC14A2A_LIBRARY_WNC_WAKEUP                          NC
+#define MBED_CONF_WNC14A2A_LIBRARY_WNC_RESET                           NC
+#define MBED_CONF_WNC14A2A_LIBRARY_WNC_LVLTRANSLATOR                   NC
+#define MBED_CONF_WNC14A2A_LIBRARY_WNC_CTS                             NC
+#define MBED_CONF_WNC14A2A_LIBRARY_WNC_RXD                             NC
+#define MBED_CONF_WNC14A2A_LIBRARY_WNC_TXD                             NC
+#endif // !defined(TARGET_FF_ARDUINO)
+
 typedef struct smsmsg_t {
         string number;
         string date;

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -1,38 +1,6 @@
 {
     "name": "wnc14a2a-library",
     "config": {
-         "wnc-rxd" : {
-            "help" : "WNC Module RX Serial Line",
-            "value": "D11"
-        },
-         "wnc-txd" : {
-            "help" : "WNC Module TX Serial Line",
-            "value": "D12"
-        },
-         "wnc-cts" : {
-            "help" : "WNC Module CTS Line",
-            "value": "D10"
-        },
-         "wnc-rx-boot-sel" : {
-            "help" : "WNC Module RX Boot Select Line",
-            "value": "D1"
-        },
-         "wnc-power-on" : {
-            "help" : "WNC Module Power ON Line",
-            "value": "D2"
-        },
-         "wnc-wakeup" : {
-            "help" : "WNC Module Wakeup Line",
-            "value": "D6"
-        },
-         "wnc-reset" : {
-            "help" : "WNC Module Reset Line",
-            "value": "D8"
-        },
-         "wnc-lvltranslator" : {
-            "help" : "WNC Module Level Translator enable Line",
-            "value": "D9"
-        },
         "wnc-debug": {
             "help" : "enable or disable WNC debug messages.",
             "value": "false"


### PR DESCRIPTION
Only part of Mbed boards define Arduino-pins, thus driver cannot
expect that these are always defined. Also, only application is
allowed to override library defines. Other libraries (easy-connect)
cannot provide overrides.

This PR enables ARDUINO pin mapping only when target supports it.

For. ex. board like MTB_UBLOX_ODIN_W2 does not specify Arduino pins at all, and would not compile if this driver is present.

This issue mainly appears as this driver is part of easy-connect.